### PR TITLE
Move help from Discourse to GitHub Discussions

### DIFF
--- a/content/nornir/_index.md
+++ b/content/nornir/_index.md
@@ -6,6 +6,6 @@ layout: "section_no_title"
 
 # Nornir
 
-[Github](https://github.com/nornir-automation/nornir/) [Documentation](https://nornir.readthedocs.io) [Plugins](/nornir/plugins/) [Help](https://nornir.discourse.group/)
+[Github](https://github.com/nornir-automation/nornir/) [Documentation](https://nornir.readthedocs.io) [Plugins](/nornir/plugins/) [Help](https://github.com/nornir-automation/nornir/discussions)
 
 Nornir is a pure Python automation framework intented to be used directly from Python. While most automation frameworks use their own Domain Specific Language (DSL) which you use to describe what you want to have done, Nornir lets you control everything from Python.


### PR DESCRIPTION
Should the same thing be done for the Gornir project? Or just remove the help section from there for now?