### PR TITLE
Add filtering deep dive post, fix discourse support link

### DIFF
--- a/content/posts/2021/04-19-filtering-deep-dive.md
+++ b/content/posts/2021/04-19-filtering-deep-dive.md
@@ -4,6 +4,9 @@ date: "2021-04-19"
 tags: ["nornir", "filtering", "guest"]
 ---
 
+_This is a guest post by Daniel Teycheney, for more content like this and other interesting stuff you can visit the following [youtube channel](https://www.youtube.com/channel/UCTjhvZ6rj2Hya4nszBfXoRg), [github account](https://github.com/writememe), [blog](https://blog.danielteycheney.com/) and [twitter feed](https://twitter.com/danielteycheney)._
+
+---
 
 nornir is a first-class automation framework, so if you are reading this page, you're probably here to learn more. One of the aspects of which sets nornir apart is filtering.  
 

--- a/content/posts/2021/04-19-filtering-deep-dive.md
+++ b/content/posts/2021/04-19-filtering-deep-dive.md
@@ -1,0 +1,34 @@
+---
+title: "How To: Filtering Deep Dive"
+date: "2021-04-19"
+tags: ["nornir", "filtering", "guest"]
+---
+
+
+nornir is a first-class automation framework, so if you are reading this page, you're probably here to learn more. One of the aspects of which sets nornir apart is filtering.  
+
+A new how-to guide has been published to the official documentation, walking through a series of use-cases and examples on how to leverage the power
+and flexibility of `nornir filtering`.
+
+Some of the topics covered are:  
+
+- Introduction into custom inventory data  
+- How to store, access, view and troubleshoot custom data  
+- Basic/intermediate filtering using the `filter` method  
+- Advanced filtering using the `F` object  
+- Advanced filtering using filter functions  
+
+A sample inventory is weaved throughout the how-to guide, so that the concepts being portrayed are contextually revelant to a real world use case. Below is the
+link to the how-to guide:   
+
+[nornir official documentation - filtering deep dive](https://nornir.readthedocs.io/en/latest/howto/filtering_deep_dive.html)
+
+## Further resources
+
+If you'd like to learn more, below are some links to various resources which also touch on nornir filtering:  
+
+[nornir filtering cheatsheet](https://github.com/nornir-automation/nornir/discussions/647)  
+[nornir-workshop - jupyter notebook filtering examples](https://github.com/dravetech/nornir-workshop/blob/master/notebooks/3_filtering.ipynb)  
+[nornir-workshop - Full Presentation](https://github.com/dravetech/nornir-workshop/blob/master/nornir-workshop.pdf)  
+[nornir-filtering-demo - repository](https://github.com/writememe/nornir-filtering-demo)  
+[nornir-filtering-demo - Video](https://www.youtube.com/watch?v=aGyLKITj4Nw)  

--- a/content/support.md
+++ b/content/support.md
@@ -11,7 +11,7 @@ layout: "section_no_title"
 You can find community-driven support via the following channels:
 
 1. On [network to code](https://networktocode.herokuapp.com/)'s slack, `#nornir` channel
-2. On [discourse](https://nornir.discourse.group/)
+2. On [github discussions](https://github.com/nornir-automation/nornir/discussions)
 
 ---
 


### PR DESCRIPTION
## content/posts/2021/04-19-filtering-deep-dive.md

I've written the blog post, feel free to adjust this as you like. I think the site runs on hugo but I wasn't sure to generate a new post/test this?

This will resolve #22 

## content/support.md

This is to change the support docs to point to the Github discussions page instead of discourse.

This will resolve #21 