### PR TITLE
table inventory plugin added

### DIFF
--- a/data/nornir/plugins.yaml
+++ b/data/nornir/plugins.yaml
@@ -144,3 +144,11 @@ repositories:
         - tasks
       description: |
             Collection of tasks to interact with HTTP Servers
+
+    - url: https://github.com/jiujing/nornir_table_inventory
+      name: nornir_table_inventory
+      maintainer: "[jiujing](https://github.com/jiujing)"
+      plugin_types:
+        - inventory
+      description: |
+          Allows  managing inventory by table file(CSV or Excel)


### PR DESCRIPTION
The nornir_table_inventory is Nornir plugin for inventory.It can manage inventory by table file(CSV or Excel). Netmiko connections support only.

You can manage inventory easily by flat data in table file such as excel or csv.