### PR TITLE
update plugins.yaml with librenms plugin

### DIFF
--- a/data/nornir/plugins.yaml
+++ b/data/nornir/plugins.yaml
@@ -194,3 +194,11 @@ repositories:
         - processors
       description: |
           Collection of functions and processors for generating nice looking output with [rich](https://github.com/Textualize/rich)
+    
+    - url: https://github.com/shamalawy/nornir-librenms
+      name: nornir_ansible
+      maintainer: "[carlmontanari](https://github.com/shamalawy)"
+      plugin_types:
+      - inventory
+      description: |
+          Use LibreNMS as source of inventory to generate hosts, groups and many attriutes like version, model etc.


### PR DESCRIPTION
This plugin uses LibreNMS as an inventory source, it automatically greates groups based on SNMP location collected by libreNMS, also attaches attributes to devices like os version, model etc. to make it easy to filter using nornir