### PR TITLE
add nornir-nuts

### DIFF
--- a/data/nornir/plugins.yaml
+++ b/data/nornir/plugins.yaml
@@ -246,3 +246,11 @@ repositories:
       - tasks
       description: |
           Nornir plugin for [Infrahub](https://github.com/opsmill/infrahub)
+
+    - url: https://github.com/network-unit-testing-system/nornir_nuts
+      name: nornir-nuts
+      maintainer: "[nuts](https://github.com/network-unit-testing-system)"
+      plugin_types:
+        - runners
+      description: |
+          Nornir plugins designed for use with Nuts; `CachedThreaded Runner`


### PR DESCRIPTION
Add `nornir-nuts` plugin to the list. The `CachedThreaded` runner is for edge cases, but you never know who finds it useful. 